### PR TITLE
お知らせカードリストコンポーネントの作成

### DIFF
--- a/src/components/news/NewsCard/index.stories.tsx
+++ b/src/components/news/NewsCard/index.stories.tsx
@@ -11,8 +11,9 @@ export default {
   },
 } as Meta;
 
-const Template: Story = ({ date, tagList, newsTitle, mainText }) => (
+const Template: Story = ({ id, date, tagList, newsTitle, mainText }) => (
   <NewsCard
+    id={id}
     date={date}
     tagList={tagList}
     newsTitle={newsTitle}
@@ -22,6 +23,7 @@ const Template: Story = ({ date, tagList, newsTitle, mainText }) => (
 
 export const newsCard = Template.bind({});
 newsCard.args = {
+  id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
   date: '2017-07-21T17:32:28',
   tagList: [
     {

--- a/src/components/news/NewsCard/index.tsx
+++ b/src/components/news/NewsCard/index.tsx
@@ -2,21 +2,9 @@ import React from 'react';
 import dayjs from 'dayjs';
 
 import 'src/styles/NewsCard.css';
+import { NewsCardDataType } from 'src/types/type';
 
-type tagProps = {
-  id: string;
-  color: 'red' | 'yellow' | 'orange';
-  name: string;
-};
-
-type Props = {
-  date: string;
-  tagList: tagProps[];
-  newsTitle: string;
-  mainText: string;
-};
-
-const NewsCard = ({ date, tagList, newsTitle, mainText }: Props) => (
+const NewsCard = ({ date, tagList, newsTitle, mainText }: NewsCardDataType) => (
   <div className="news-card">
     <div className="news-card__data-and-tag">
       <p className="news-card__data-and-tag__date">

--- a/src/components/news/NewsCardList/index.stories.tsx
+++ b/src/components/news/NewsCardList/index.stories.tsx
@@ -14,6 +14,7 @@ export default {
 
 const dummyCardList: NewsCardDataType[] = [
   {
+    id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
     date: '2017-07-21T17:32:28',
     tagList: [
       {
@@ -34,10 +35,11 @@ const dummyCardList: NewsCardDataType[] = [
       '本日の19:00からメンテナンスのため、一時間ほどのサービス停止を予定しています。\n再開しだいメールにてアナウンスさせていただきます。\nご迷惑をおかけしますが、ご理解ご協力のほどをよろしくお願いいたします。',
   },
   {
+    id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186d',
     date: '2017-07-21T17:32:28',
     tagList: [
       {
-        id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
+        id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186d',
         name: '重要',
         color: 'red',
         tag_group: 'information',

--- a/src/components/news/NewsCardList/index.stories.tsx
+++ b/src/components/news/NewsCardList/index.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { NewsCardDataType } from 'src/types/type';
+import NewsCardList, { NewsCardListProps } from './index';
+
+export default {
+  component: NewsCardList,
+  title: 'news/NewsCardList',
+  parameters: {
+    backgrounds: {
+      default: 'dark',
+    },
+  },
+} as Meta;
+
+const dummyCardList: NewsCardDataType[] = [
+  {
+    date: '2017-07-21T17:32:28',
+    tagList: [
+      {
+        id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
+        name: '重要',
+        color: 'red',
+        tag_group: 'information',
+      },
+      {
+        id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186d',
+        name: 'メンテナンス',
+        color: 'yellow',
+        tag_group: 'information',
+      },
+    ],
+    newsTitle: 'メンテナンスのお知らせ!!!!!',
+    mainText:
+      '本日の19:00からメンテナンスのため、一時間ほどのサービス停止を予定しています。\n再開しだいメールにてアナウンスさせていただきます。\nご迷惑をおかけしますが、ご理解ご協力のほどをよろしくお願いいたします。',
+  },
+  {
+    date: '2017-07-21T17:32:28',
+    tagList: [
+      {
+        id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
+        name: '重要',
+        color: 'red',
+        tag_group: 'information',
+      },
+      {
+        id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186d',
+        name: 'メンテナンス',
+        color: 'yellow',
+        tag_group: 'information',
+      },
+    ],
+    newsTitle: 'メンテナンスのお知らせ',
+    mainText:
+      '本日の19:00からメンテナンスのため、一時間ほどのサービス停止を予定しています。\n再開しだいメールにてアナウンスさせていただきます。\nご迷惑をおかけしますが、ご理解ご協力のほどをよろしくお願いいたします。',
+  },
+];
+
+const Template: Story<NewsCardListProps> = (args) => <NewsCardList {...args} />;
+
+export const newsCardList = Template.bind({});
+newsCardList.args = {
+  newsDataList: dummyCardList,
+};

--- a/src/components/news/NewsCardList/index.tsx
+++ b/src/components/news/NewsCardList/index.tsx
@@ -11,7 +11,7 @@ export type NewsCardListProps = {
 const NewCardList = ({ newsDataList }: NewsCardListProps) => (
   <div className="news-card-list">
     {newsDataList.map((newsData: NewsCardDataType) => (
-      <NewsCard {...newsData} />
+      <NewsCard key={newsData.id} {...newsData} />
     ))}
   </div>
 );

--- a/src/components/news/NewsCardList/index.tsx
+++ b/src/components/news/NewsCardList/index.tsx
@@ -2,16 +2,17 @@ import React from 'react';
 
 import { NewsCardDataType } from 'src/types/type';
 import NewsCard from '../NewsCard';
+import 'src/styles/NewsCardList.css';
 
 export type NewsCardListProps = {
   newsDataList: NewsCardDataType[];
 };
 
 const NewCardList = ({ newsDataList }: NewsCardListProps) => (
-  <>
+  <div className="news-card-list">
     {newsDataList.map((newsData: NewsCardDataType) => (
       <NewsCard {...newsData} />
     ))}
-  </>
+  </div>
 );
 export default NewCardList;

--- a/src/components/news/NewsCardList/index.tsx
+++ b/src/components/news/NewsCardList/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { NewsCardDataType } from 'src/types/type';
+import NewsCard from '../NewsCard';
+
+export type NewsCardListProps = {
+  newsDataList: NewsCardDataType[];
+};
+
+const NewCardList = ({ newsDataList }: NewsCardListProps) => (
+  <>
+    {newsDataList.map((newsData: NewsCardDataType) => (
+      <NewsCard {...newsData} />
+    ))}
+  </>
+);
+export default NewCardList;

--- a/src/styles/NewsCard.css
+++ b/src/styles/NewsCard.css
@@ -10,30 +10,28 @@
 
 .news-card__data-and-tag {
   display: flex;
+  flex-direction: row;
+  gap: 6px;
   padding: 9px 0px;
 }
 
 .news-card__data-and-tag__date {
   font-weight: bold;
-  margin-right: 6px;
 }
 
 .news-card__data-and-tag__tag__red {
   color: white;
   background-color: red;
-  margin-right: 6px;
 }
 
 .news-card__data-and-tag__tag__yellow {
   color: white;
   background-color: yellow;
-  margin-right: 6px;
 }
 
 .news-card__data-and-tag__tag__orange {
   color: white;
   background-color: orange;
-  margin-right: 6px;
 }
 
 .news-card__main-text {

--- a/src/styles/NewsCard.css
+++ b/src/styles/NewsCard.css
@@ -16,25 +16,25 @@
 
 .news-card__data-and-tag__date {
   font-weight: bold;
-  margin-right: 10px;
+  margin-right: 6px;
 }
 
 .news-card__data-and-tag__tag__red {
   color: white;
   background-color: red;
-  margin-right: 10px;
+  margin-right: 6px;
 }
 
 .news-card__data-and-tag__tag__yellow {
   color: white;
   background-color: yellow;
-  margin-right: 10px;
+  margin-right: 6px;
 }
 
 .news-card__data-and-tag__tag__orange {
   color: white;
   background-color: orange;
-  margin-right: 10px;
+  margin-right: 6px;
 }
 
 .news-card__main-text {

--- a/src/styles/NewsCard.css
+++ b/src/styles/NewsCard.css
@@ -1,5 +1,6 @@
 .news-card {
   width: 100%;
+  margin-bottom: 10px;
   padding: 8px 8px;
   align-items: center;
   justify-content: center;

--- a/src/styles/NewsCard.css
+++ b/src/styles/NewsCard.css
@@ -1,6 +1,5 @@
 .news-card {
   width: 100%;
-  margin-bottom: 10px;
   padding: 8px 8px;
   align-items: center;
   justify-content: center;

--- a/src/styles/NewsCardList.css
+++ b/src/styles/NewsCardList.css
@@ -1,0 +1,5 @@
+.news-card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -1,0 +1,13 @@
+export type NewsCardTagType = {
+  id: string;
+  color: 'red' | 'yellow' | 'orange';
+  name: string;
+  tag_group: string;
+};
+
+export type NewsCardDataType = {
+  date: string;
+  tagList: NewsCardTagType[];
+  newsTitle: string;
+  mainText: string;
+};

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -6,6 +6,7 @@ export type NewsCardTagType = {
 };
 
 export type NewsCardDataType = {
+  id: string;
   date: string;
   tagList: NewsCardTagType[];
   newsTitle: string;


### PR DESCRIPTION
## 🔨 変更内容
- お知らせカードリストのコンポーネントを作成
- お知らせカードに関する共通の types の定義を追加

## 📷 スクリーンショット
<img width="1170" alt="スクリーンショット 2022-06-02 18 53 52" src="https://user-images.githubusercontent.com/68209431/171604907-d9778daf-0f5c-43a3-a72c-413c3c89530e.png">
