### PR TITLE
お知らせ情報のデータを API から取得してきたものに変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "axios": "^0.27.2",
     "dayjs": "^1.11.2",
     "next": "12.1.0",
     "react": "17.0.2",

--- a/src/components/news/NewsCard/index.stories.tsx
+++ b/src/components/news/NewsCard/index.stories.tsx
@@ -11,21 +11,21 @@ export default {
   },
 } as Meta;
 
-const Template: Story = ({ id, date, tagList, newsTitle, mainText }) => (
+const Template: Story = ({ id, announcedDate, tags, title, detail }) => (
   <NewsCard
     id={id}
-    date={date}
-    tagList={tagList}
-    newsTitle={newsTitle}
-    mainText={mainText}
+    announcedDate={announcedDate}
+    tags={tags}
+    title={title}
+    detail={detail}
   />
 );
 
 export const newsCard = Template.bind({});
 newsCard.args = {
   id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
-  date: '2017-07-21T17:32:28',
-  tagList: [
+  announcedDate: '2017-07-21T17:32:28',
+  tags: [
     {
       id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
       name: '重要',
@@ -39,7 +39,7 @@ newsCard.args = {
       tag_group: 'information',
     },
   ],
-  newsTitle: 'メンテナンスのお知らせ',
-  mainText:
+  title: 'メンテナンスのお知らせ',
+  detail:
     '本日の19:00からメンテナンスのため、一時間ほどのサービス停止を予定しています。\n再開しだいメールにてアナウンスさせていただきます。\nご迷惑をおかけしますが、ご理解ご協力のほどをよろしくお願いいたします。',
 };

--- a/src/components/news/NewsCard/index.tsx
+++ b/src/components/news/NewsCard/index.tsx
@@ -3,13 +3,14 @@ import dayjs from 'dayjs';
 
 import { NewsCardDataType } from 'src/types/type';
 
-const NewsCard = ({ date, tagList, newsTitle, mainText }: NewsCardDataType) => (
+// ano
+const NewsCard = ({ announcedDate, tags, title, detail }: NewsCardDataType) => (
   <div className="news-card">
     <div className="news-card__data-and-tag">
       <p className="news-card__data-and-tag__date">
-        {dayjs(date).format('YYYY/MM/DD')}
+        {dayjs(announcedDate).format('YYYY/MM/DD')}
       </p>
-      {tagList.map((tag) => (
+      {tags.map((tag) => (
         <p
           key={tag.id}
           className={`news-card__data-and-tag__tag__${tag.color}`}
@@ -18,8 +19,8 @@ const NewsCard = ({ date, tagList, newsTitle, mainText }: NewsCardDataType) => (
         </p>
       ))}
     </div>
-    <p>{newsTitle}</p>
-    <p className="news-card__main-text">{mainText}</p>
+    <p>{title}</p>
+    <p className="news-card__main-text">{detail}</p>
   </div>
 );
 

--- a/src/components/news/NewsCardList/index.stories.tsx
+++ b/src/components/news/NewsCardList/index.stories.tsx
@@ -15,8 +15,8 @@ export default {
 const dummyCardList: NewsCardDataType[] = [
   {
     id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
-    date: '2017-07-21T17:32:28',
-    tagList: [
+    announcedDate: '2017-07-21T17:32:28',
+    tags: [
       {
         id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
         name: '重要',
@@ -30,14 +30,14 @@ const dummyCardList: NewsCardDataType[] = [
         tag_group: 'information',
       },
     ],
-    newsTitle: 'メンテナンスのお知らせ!!!!!',
-    mainText:
+    title: 'メンテナンスのお知らせ!!!!!',
+    detail:
       '本日の19:00からメンテナンスのため、一時間ほどのサービス停止を予定しています。\n再開しだいメールにてアナウンスさせていただきます。\nご迷惑をおかけしますが、ご理解ご協力のほどをよろしくお願いいたします。',
   },
   {
     id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186d',
-    date: '2017-07-21T17:32:28',
-    tagList: [
+    announcedDate: '2017-07-21T17:32:28',
+    tags: [
       {
         id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186d',
         name: '重要',
@@ -51,8 +51,8 @@ const dummyCardList: NewsCardDataType[] = [
         tag_group: 'information',
       },
     ],
-    newsTitle: 'メンテナンスのお知らせ',
-    mainText:
+    title: 'メンテナンスのお知らせ',
+    detail:
       '本日の19:00からメンテナンスのため、一時間ほどのサービス停止を予定しています。\n再開しだいメールにてアナウンスさせていただきます。\nご迷惑をおかけしますが、ご理解ご協力のほどをよろしくお願いいたします。',
   },
 ];

--- a/src/components/news/NewsCardList/index.tsx
+++ b/src/components/news/NewsCardList/index.tsx
@@ -4,14 +4,18 @@ import { NewsCardDataType } from 'src/types/type';
 import NewsCard from '../NewsCard';
 
 export type NewsCardListProps = {
-  newsDataList: NewsCardDataType[];
+  newsDataList: NewsCardDataType[] | undefined;
 };
 
 const NewCardList = ({ newsDataList }: NewsCardListProps) => (
   <div className="news-card-list">
-    {newsDataList.map((newsData: NewsCardDataType) => (
-      <NewsCard key={newsData.id} {...newsData} />
-    ))}
+    {newsDataList === undefined ? (
+      <p>お知らせはありません</p>
+    ) : (
+      newsDataList.map((newsData: NewsCardDataType) => (
+        <NewsCard key={newsData.id} {...newsData} />
+      ))
+    )}
   </div>
 );
 export default NewCardList;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import { useMediaLayout } from 'use-media';
+import axios from 'axios';
 
 import { Container, Main } from 'src/styles/Home';
 import { Header } from 'src/components/organisms/Header';
@@ -9,58 +10,24 @@ import { Headline } from 'src/components/atoms/Headline';
 import Card from 'src/components/common/card/index';
 import NewCardList from 'src/components/news/NewsCardList';
 import { NewsCardDataType } from 'src/types/type';
+import { useEffect, useState } from 'react';
 
 const Home: NextPage = () => {
   const isWide = useMediaLayout({ minWidth: '1000px' });
   const headlineFontSize = isWide ? 'large' : 'middle';
 
+  const [newsCardData, setNewsCardData] = useState<NewsCardDataType[]>();
+
+  useEffect(() => {
+    axios.get('http://localhost:3000/informations').then((res) => {
+      setNewsCardData(res.data);
+    });
+  }, []);
+
   // TODO: API データに置き換えた後に削除する
   const dummyImageUrl = 'https://picsum.photos/300/200';
   const dummyCardName = '文房具セール';
-  const dummyCardList: NewsCardDataType[] = [
-    {
-      id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
-      date: '2017-07-21T17:32:28',
-      tagList: [
-        {
-          id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
-          name: '重要',
-          color: 'red',
-          tag_group: 'information',
-        },
-        {
-          id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186d',
-          name: 'メンテナンス',
-          color: 'yellow',
-          tag_group: 'information',
-        },
-      ],
-      newsTitle: 'メンテナンスのお知らせ!!!!!',
-      mainText:
-        '本日の19:00からメンテナンスのため、一時間ほどのサービス停止を予定しています。\n再開しだいメールにてアナウンスさせていただきます。\nご迷惑をおかけしますが、ご理解ご協力のほどをよろしくお願いいたします。',
-    },
-    {
-      id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186d',
-      date: '2017-07-21T17:32:28',
-      tagList: [
-        {
-          id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186d',
-          name: '重要',
-          color: 'red',
-          tag_group: 'information',
-        },
-        {
-          id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186d',
-          name: 'メンテナンス',
-          color: 'yellow',
-          tag_group: 'information',
-        },
-      ],
-      newsTitle: 'メンテナンスのお知らせ',
-      mainText:
-        '本日の19:00からメンテナンスのため、一時間ほどのサービス停止を予定しています。\n再開しだいメールにてアナウンスさせていただきます。\nご迷惑をおかけしますが、ご理解ご協力のほどをよろしくお願いいたします。',
-    },
-  ];
+
   return (
     <Container>
       <Head>
@@ -81,7 +48,7 @@ const Home: NextPage = () => {
           <Headline label="お知らせ" headlineTypes={headlineFontSize} />
         </div>
         <div className="news-card-top-page">
-          <NewCardList newsDataList={dummyCardList} />
+          <NewCardList newsDataList={newsCardData} />
         </div>
         <div className="headline">
           <Headline label="カテゴリ" headlineTypes={headlineFontSize} />

--- a/src/styles/NewsCard.css
+++ b/src/styles/NewsCard.css
@@ -34,6 +34,11 @@
   background-color: orange;
 }
 
+.news-card__data-and-tag__tag__mediumpurple {
+  color: white;
+  background-color: mediumpurple;
+}
+
 .news-card__main-text {
   white-space: pre-wrap;
 }

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -1,14 +1,14 @@
 export type NewsCardTagType = {
   id: string;
-  color: 'red' | 'yellow' | 'orange';
+  color: 'red' | 'yellow' | 'orange' | 'mediumpurple';
   name: string;
   tag_group: string;
 };
 
 export type NewsCardDataType = {
   id: string;
-  date: string;
-  tagList: NewsCardTagType[];
-  newsTitle: string;
-  mainText: string;
+  announced_at: string;
+  tags: NewsCardTagType[];
+  title: string;
+  detail: string;
 };

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -7,7 +7,7 @@ export type NewsCardTagType = {
 
 export type NewsCardDataType = {
   id: string;
-  announced_at: string;
+  announcedDate: string;
   tags: NewsCardTagType[];
   title: string;
   detail: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4108,6 +4108,14 @@ axe-core@^4.3.5:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
   integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
+axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -6464,6 +6472,11 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+follow-redirects@^1.14.9:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
+  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -6513,6 +6526,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"


### PR DESCRIPTION
## 🔨 変更内容
- お知らせ情報のデータを API から取得してきたものに変更
- キャンペーンとカテゴリーの部分はダミーデータのままです

## 📸 スクリーンショット
![スクリーンショット 2022-06-03 16 00 57](https://user-images.githubusercontent.com/68209431/171804018-3de5627b-55fa-4c13-a270-8a0af24688fc.png)
